### PR TITLE
Remove unused Node installation

### DIFF
--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -26,9 +26,6 @@ jobs:
         ]
     runs-on: ${{ matrix.os.os }}
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.version }}
       - uses: actions/checkout@v3
       - name: Set up R ${{ matrix.r-version }}
         uses: r-lib/actions/setup-r@f57f1301a053485946083d7a45022b278929a78a


### PR DESCRIPTION
I didn't see Node being used anywhere. Is it okay to remove this?