### PR TITLE
Misc workflow improvements for security and easier maintenance

### DIFF
--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -32,10 +32,16 @@ jobs:
         with:
           r-version: ${{ matrix.r-version }}
       - name: Build source package
-        run: R CMD build .
+        run: |
+          source_dir=$(mktemp -d)
+          (cd $source_dir; R CMD build $GITHUB_WORKSPACE)
+          echo "SOURCE_FILE=$(readlink -f $source_dir/*)" >> $GITHUB_ENV
         shell: bash
       - name: Build binary package
-        run: R CMD INSTALL --build .
+        run: |
+          binary_dir=$(mktemp -d)
+          (cd $binary_dir; R CMD INSTALL --build $GITHUB_WORKSPACE)
+          echo "BINARY_FILE=$(readlink -f $binary_dir/*)" >> $GITHUB_ENV
         shell: bash
       - name: Install RSPM CLI
         env:
@@ -47,11 +53,11 @@ jobs:
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
-        run: "./rspm add --source=local-api --path=packageManagerDemo_1.0.0.tar.gz || echo 'Already uploaded'"
+        run: "./rspm add --source=local-api --path=$SOURCE_FILE || echo 'Already uploaded'"
         shell: bash
       - name: Upload binary package
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
-        run: "./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=packageManagerDemo_1.0.0_R_x86_64-pc-linux-gnu.tar.gz || echo 'Already uploaded'"
+        run: "./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=$BINARY_FILE || echo 'Already uploaded'"
         shell: bash

--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -44,7 +44,7 @@ jobs:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
         run: |
-          curl -O -J -H "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
+          curl -fOJH "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
           chmod +x ./rspm
         shell: bash
       - name: Upload source package

--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -38,15 +38,20 @@ jobs:
         run: R CMD INSTALL --build .
         shell: bash
       - name: Install RSPM CLI
-        run: "curl -O -J -H \"Authorization: Bearer ${{ matrix.package-manager.token }}\" ${{ matrix.package-manager.endpoint }}/__api__/download && chmod +x ./rspm"
+        env:
+          PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
+          PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
+        run: "curl -O -J -H \"Authorization: Bearer ${PACKAGEMANAGER_TOKEN}\" ${PACKAGEMANAGER_ADDRESS}/__api__/download && chmod +x ./rspm"
         shell: bash
       - name: Upload source package
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
-        run: "PACKAGEMANAGER_TOKEN=${{ matrix.package-manager.token }} ./rspm add --source=local-api --path=packageManagerDemo_1.0.0.tar.gz || echo 'Already uploaded'"
+          PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
+        run: "./rspm add --source=local-api --path=packageManagerDemo_1.0.0.tar.gz || echo 'Already uploaded'"
         shell: bash
       - name: Upload binary package
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
-        run: "PACKAGEMANAGER_TOKEN=${{ matrix.package-manager.token }} ./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=packageManagerDemo_1.0.0_R_x86_64-pc-linux-gnu.tar.gz || echo 'Already uploaded'"
+          PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
+        run: "./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=packageManagerDemo_1.0.0_R_x86_64-pc-linux-gnu.tar.gz || echo 'Already uploaded'"
         shell: bash

--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -16,9 +16,9 @@ jobs:
         r-version: ['3.6.3', '4.1.3']
         os: [ {os: "ubuntu-20.04", distro: "focal"}, {os: "ubuntu-18.04", distro: "bionic"} ]
         package-manager: [
-          {token: "PACKAGEMANAGER_TOKEN_SOLO", endpoint: "https://solo.rstudiopm.com"},
-          {token: "PACKAGEMANAGER_TOKEN_S3", endpoint: "https://s3.rstudiopm.com"},
-          {token: "PACKAGEMANAGER_TOKEN_CLUSTER", endpoint: "https://cluster.rstudiopm.com"},
+          {endpoint: "https://solo.rstudiopm.com", token: "PACKAGEMANAGER_TOKEN_SOLO"},
+          {endpoint: "https://s3.rstudiopm.com", token: "PACKAGEMANAGER_TOKEN_S3"},
+          {endpoint: "https://cluster.rstudiopm.com", token: "PACKAGEMANAGER_TOKEN_CLUSTER"},
         ]
     runs-on: ${{ matrix.os.os }}
     steps:

--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@f57f1301a053485946083d7a45022b278929a78a
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
       - name: Build source package

--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -11,18 +11,14 @@ permissions:
 
 jobs:
   build:
-    env:
-      PACKAGEMANAGER_TOKEN_SOLO: ${{ secrets.PACKAGEMANAGER_TOKEN_SOLO }}
-      PACKAGEMANAGER_TOKEN_CLUSTER: ${{ secrets.PACKAGEMANAGER_TOKEN_CLUSTER }}
-      PACKAGEMANAGER_TOKEN_S3: ${{ secrets.PACKAGEMANAGER_TOKEN_S3 }}
     strategy:
       matrix:
         r-version: ['3.6.3', '4.1.3']
         os: [ {os: "ubuntu-20.04", distro: "focal"}, {os: "ubuntu-18.04", distro: "bionic"} ]
         package-manager: [
-          {token: "$PACKAGEMANAGER_TOKEN_SOLO", endpoint: "https://solo.rstudiopm.com"},
-          {token: "$PACKAGEMANAGER_TOKEN_S3", endpoint: "https://s3.rstudiopm.com"},
-          {token: "$PACKAGEMANAGER_TOKEN_CLUSTER", endpoint: "https://cluster.rstudiopm.com"},
+          {token: "PACKAGEMANAGER_TOKEN_SOLO", endpoint: "https://solo.rstudiopm.com"},
+          {token: "PACKAGEMANAGER_TOKEN_S3", endpoint: "https://s3.rstudiopm.com"},
+          {token: "PACKAGEMANAGER_TOKEN_CLUSTER", endpoint: "https://cluster.rstudiopm.com"},
         ]
     runs-on: ${{ matrix.os.os }}
     steps:
@@ -46,18 +42,20 @@ jobs:
       - name: Install RSPM CLI
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
-          PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
-        run: "curl -O -J -H \"Authorization: Bearer ${PACKAGEMANAGER_TOKEN}\" ${PACKAGEMANAGER_ADDRESS}/__api__/download && chmod +x ./rspm"
+          PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
+        run: |
+          curl -O -J -H "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
+          chmod +x ./rspm
         shell: bash
       - name: Upload source package
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
-          PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
+          PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
         run: "./rspm add --source=local-api --path=$SOURCE_FILE || echo 'Already uploaded'"
         shell: bash
       - name: Upload binary package
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
-          PACKAGEMANAGER_TOKEN: ${{ matrix.package-manager.token }}
+          PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
         run: "./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=$BINARY_FILE || echo 'Already uploaded'"
         shell: bash

--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Build source package
         run: |
           source_dir=$(mktemp -d)
-          (cd $source_dir; R CMD build $GITHUB_WORKSPACE)
-          echo "SOURCE_FILE=$(readlink -f $source_dir/*)" >> $GITHUB_ENV
+          (cd $source_dir; R CMD build $OLDPWD)
+          echo "SOURCE_FILE=$(ls -d $source_dir/*)" >> $GITHUB_ENV
         shell: bash
       - name: Build binary package
         run: |
           binary_dir=$(mktemp -d)
-          (cd $binary_dir; R CMD INSTALL --build $GITHUB_WORKSPACE)
-          echo "BINARY_FILE=$(readlink -f $binary_dir/*)" >> $GITHUB_ENV
+          (cd $binary_dir; R CMD INSTALL --build $OLDPWD)
+          echo "BINARY_FILE=$(ls -d $binary_dir/*)" >> $GITHUB_ENV
         shell: bash
       - name: Install RSPM CLI
         env:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Since the CLI major and minor versions need to match the server, we recommend do
 `rspm` tool from the server directly, e.g.:
 
 ```bash
-curl -O -J -H "Authorization: Bearer [TOKEN]" http(s)://[YOUR-RSPM-INSTANCE]/__api__/download
+curl -fOJH "Authorization: Bearer [TOKEN]" http(s)://[YOUR-RSPM-INSTANCE]/__api__/download
 chmod +x ./rspm
 ```
 
@@ -115,7 +115,7 @@ $ R CMD Build .
 * checking for LF line-endings in source and make files and shell scripts
 * checking for empty or unneeded directories
 * building ‘packageManagerDemo_1.0.0.tar.gz’
-$ curl -O -J -H "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
+$ curl -fOJH "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
 curl: Saved to filename 'rspm'
 $ chmod +x ./rspm
 $ ./rspm add --source=local-api --path=packageManagerDemo_1.0.0.tar.gz

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ $ R CMD build .
 * checking for file './DESCRIPTION'... OK
 ...
 * building ‘[SRC-PKG].tar.gz’
+
 $ R CMD INSTALL --build .
 * installing to library ‘/usr/local/lib/R/4.0/site-library’
 ...
-packaged installation of ‘[PKG]’ as ‘[BIN-PKG].tgz’
+packaged installation of ‘[PKG]’ as ‘[BIN-PKG].tar.gz’
 * DONE ([PKG])
-
 ```
 
 ## Upload the Source Package
@@ -108,18 +108,22 @@ $ cd package-manager-demo
 $ env | grep PACKAGEMANAGER
 PACKAGEMANAGER_TOKEN=[REDACTED]
 PACKAGEMANAGER_ADDRESS=[REDACTED]
-$ R CMD Build .
+
+$ R CMD build .
 * checking for file ‘./DESCRIPTION’ ... OK
 * preparing ‘packageManagerDemo’:
 * checking DESCRIPTION meta-information ... OK
 * checking for LF line-endings in source and make files and shell scripts
 * checking for empty or unneeded directories
 * building ‘packageManagerDemo_1.0.0.tar.gz’
+
 $ curl -fOJH "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
 curl: Saved to filename 'rspm'
 $ chmod +x ./rspm
+
 $ ./rspm add --source=local-api --path=packageManagerDemo_1.0.0.tar.gz
 Added package 'packageManagerDemo_1.0.0.tar.gz'
+
 $ ./rspm add binary --source=local-api --distribution=focal --path=packageManagerDemo_1.0.0_R_x86_64-pc-linux-gnu.tar.gz
 Added packageManagerDemo with version 1.0.0 for focal and R 4.1 for any architecture
 ```


### PR DESCRIPTION
A couple of miscellaneous workflow improvements:
- Use secrets via environment variables instead of passing them on the command line for better security, as recommended by GitHub: https://docs.github.com/en/actions/security-guides/encrypted-secrets#example-using-bash
- Determine built package paths dynamically rather than hardcoding something like `--path=packageManagerDemo_1.0.0.tar.gz`, so the workflow is easier to copy for other packages and maintain when bumping package versions.
- Update curl command to exit on failure, match the RSPM admin guide, and various README fixes