### PR TITLE
Only publish when pushing to main; test workflow without having to open a PR

### DIFF
--- a/.github/workflows/package-manager-demo.yml
+++ b/.github/workflows/package-manager-demo.yml
@@ -1,10 +1,6 @@
 name: package-manager-demo
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 
 permissions:
   contents: read
@@ -62,6 +58,7 @@ jobs:
         shell: bash
 
       - name: Upload source package
+        if: github.ref == 'refs/heads/main'
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
@@ -69,6 +66,7 @@ jobs:
         shell: bash
 
       - name: Upload binary package
+        if: github.ref == 'refs/heads/main'
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}


### PR DESCRIPTION
Currently, packages are published on PRs to `main`, which is probably not what most users will want, especially since we don't use the `--replace` flag (https://github.com/rstudio/package-manager-demo/issues/10). This changes the workflow so that packages are only published on pushes to `main`. It would be nice to have some sort of dry-run publish capability to test the publishing step though, so maybe a future enhancement for RSPM.

I also changed the workflow to run on all branches/PRs for easier testing. Previously, it was hard to iterate on workflow changes as you had to open a PR on `main`. This should be ok to do now that publishing only happens on a `main` push. I do think there will be users who want both behaviors though. Users that want a standalone workflow for publishing might want the workflow to run on `main` only. Users that want to add a publishing step to their existing build & test workflow would probably be running that workflow on all branches.