### PR TITLE
Fix Windows builds for R; update OSs for Ubuntu 18 deprecation

### DIFF
--- a/.github/workflows/package-manager-python-demo.yml
+++ b/.github/workflows/package-manager-python-demo.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         os:
+          - {os: "ubuntu-22.04", distro: "jammy"}
           - {os: "ubuntu-20.04", distro: "focal" }
-          - {os: "ubuntu-18.04", distro: "bionic"}
           - {os: "windows-latest", distro: "windows"}
         package-manager:
           - {endpoint: "https://solo.rstudiopm.com", token: "PACKAGEMANAGER_TOKEN_PYTHON_SOLO"}

--- a/.github/workflows/package-manager-r-demo.yml
+++ b/.github/workflows/package-manager-r-demo.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         r-version: ['3.6.3', '4.1.3']
         os:
+          - {os: "ubuntu-22.04", distro: "jammy"}
           - {os: "ubuntu-20.04", distro: "focal" }
-          - {os: "ubuntu-18.04", distro: "bionic"}
           - {os: "windows-latest", distro: "windows"}
         package-manager:
           - {endpoint: "https://solo.rstudiopm.com", token: "PACKAGEMANAGER_TOKEN_SOLO"}

--- a/.github/workflows/package-manager-r-demo.yml
+++ b/.github/workflows/package-manager-r-demo.yml
@@ -55,7 +55,8 @@ jobs:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
         run: |
-          curl -fOJH "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download
+          os=$(R -s -e "cat(tolower(Sys.info()['sysname']))")
+          curl -f -o rspm -H "Authorization: Bearer ${PACKAGEMANAGER_TOKEN}" ${PACKAGEMANAGER_ADDRESS}/__api__/download?os=${os}
           chmod +x ./rspm
         shell: bash
 

--- a/.github/workflows/package-manager-r-demo.yml
+++ b/.github/workflows/package-manager-r-demo.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        r-version: ['3.6.3', '4.1.3']
+        r-version: ['3.6.3', '4.1.3', '4.2.2']
         os:
           - {os: "ubuntu-22.04", distro: "jammy"}
           - {os: "ubuntu-20.04", distro: "focal" }

--- a/.github/workflows/package-manager-r-demo.yml
+++ b/.github/workflows/package-manager-r-demo.yml
@@ -64,7 +64,8 @@ jobs:
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
-        run: "./rspm add --source=local-api --path=$SOURCE_FILE || echo 'Already uploaded'"
+        run: |
+          ./rspm add --source=local-api --path=$SOURCE_FILE --succeed-on-existing
         shell: bash
 
       - name: Upload binary package
@@ -72,5 +73,6 @@ jobs:
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
-        run: "./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=$BINARY_FILE || echo 'Already uploaded'"
+        run: |
+          ./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=$BINARY_FILE --succeed-on-existing
         shell: bash


### PR DESCRIPTION
- Fix installation of `rspm` CLI on Windows, correcting the URL to specify an `?os=[linux|windows]` query
- Use new `--succeed-on-existing` flag for `rspm add` commands, as the previous `|| echo "already uploaded"` was suppressing the Windows CLI errors
- Replace GHA-deprecated Ubuntu 18 with Ubuntu 22
- Add R 4.2 to build matrix