### PR TITLE
Fix CI after adding `--succeed-on-existing` flag

### DIFF
--- a/.github/workflows/package-manager-r-demo.yml
+++ b/.github/workflows/package-manager-r-demo.yml
@@ -65,8 +65,8 @@ jobs:
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
-        run: |
-          ./rspm add --source=local-api --path=$SOURCE_FILE --succeed-on-existing
+        run: 
+          ./rspm add --source=local-api --path=$SOURCE_FILE || echo 'Already uploaded'
         shell: bash
 
       - name: Upload binary package
@@ -74,6 +74,6 @@ jobs:
         env:
           PACKAGEMANAGER_ADDRESS: ${{ matrix.package-manager.endpoint }}
           PACKAGEMANAGER_TOKEN: ${{ secrets[matrix.package-manager.token] }}
-        run: |
-          ./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=$BINARY_FILE --succeed-on-existing
+        run: 
+          ./rspm add binary --source=local-api --distribution=${{ matrix.os.distro }} --path=$BINARY_FILE || echo 'Already uploaded'
         shell: bash


### PR DESCRIPTION
Revert commit 5d89d0ef53b228d9c97ef1e9cba8fcb6445c3923, "Fix error handling on rspm add commands, use new --succeed-on-existing flag", to fix the R package CI: https://github.com/rstudio/package-manager-demo/pull/15#issuecomment-1317550875


